### PR TITLE
Implement new endpoints for take home challenge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:2.7.3
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client
 WORKDIR /myapp
 COPY Gemfile /myapp/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ ruby '2.7.3'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
+gem "active_model_serializers", "~> 0.10.0"
 gem 'rails', '~> 6.1'
 gem 'sidekiq'
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec'
+  gem 'pry'
   gem 'rspec-rails', '~> 5.0.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
     crass (1.0.6)
@@ -103,6 +104,9 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     pg (1.2.3)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     puma (4.3.7)
       nio4r (~> 2.0)
     racc (1.5.2)
@@ -195,6 +199,7 @@ DEPENDENCIES
   faker
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
+  pry
   puma (~> 4.1)
   rails (~> 6.1)
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.13)
+      actionpack (>= 4.1, < 7.1)
+      activemodel (>= 4.1, < 7.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.1.3.1)
       activesupport (= 6.1.3.1)
       globalid (>= 0.3.6)
@@ -67,6 +72,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
@@ -85,6 +92,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.2)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -192,6 +200,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   annotate
   bootsnap (>= 1.4.2)
   byebug

--- a/app/controllers/product_controller.rb
+++ b/app/controllers/product_controller.rb
@@ -2,7 +2,7 @@
 
 class ProductController < ApplicationController
   def index
-    @products = Product.all
+    @products = Product.all.sort_by(&:average_rating).reverse
 
     render json: @products, status: :ok
   end

--- a/app/controllers/rating_controller.rb
+++ b/app/controllers/rating_controller.rb
@@ -1,0 +1,14 @@
+
+class RatingController < ApplicationController
+  def index
+    @product_ratings = Product.find(show_params[:id]).product_ratings.order(created_at: :desc)
+
+    render json: @product_ratings, status: :ok
+  end
+
+  private
+
+  def show_params
+    params.permit(:id)
+  end
+end

--- a/app/controllers/rating_controller.rb
+++ b/app/controllers/rating_controller.rb
@@ -1,7 +1,24 @@
 
 class RatingController < ApplicationController
+  module SortBy
+    ALL = [
+      RATING = 'rating',
+      CREATED_AT = 'created_at'
+    ].freeze
+  end
+
+  module SortOrder
+    ALL = [
+      DESC = 'desc',
+      ASC = 'asc'
+    ].freeze
+  end
+
   def index
-    @product_ratings = Product.find(show_params[:id]).product_ratings.order(created_at: :desc)
+    sort_by = index_params[:sort_by] || SortBy::CREATED_AT
+    sort_order = index_params[:sort_order] || SortOrder::DESC
+
+    @product_ratings = Product.find(index_params[:id]).product_ratings.order(sort_by + ' ' + sort_order)
 
     render json: @product_ratings, status: :ok
   end
@@ -23,8 +40,8 @@ class RatingController < ApplicationController
 
   private
 
-  def show_params
-    params.permit(:id)
+  def index_params
+    params.permit(:id, :sort_by, :sort_order)
   end
 
   def create_params

--- a/app/controllers/rating_controller.rb
+++ b/app/controllers/rating_controller.rb
@@ -14,9 +14,23 @@ class RatingController < ApplicationController
     ].freeze
   end
 
+  PRODUCT_RATING_SAVE_ERROR_MESSAGE = 'Incorrect parameters for ProductRating. Valid paramters in valid_params.'.freeze
+  PRODUCT_DOES_NOT_EXIST_ERROR_MESSAGE = 'This product does not exist.'.freeze
+  PRODUCT_RATING_SORT_ERROR_MESSAGE = 'Valid sort_by values are [rating, created_at]. Valid sort_order paramters are [asc, desc]'.freeze
+  VALID_CREATE_PARAMS = {
+    :author => 'string, required',
+    :rating => 'integer (1-5 inclusive), required',
+    :review_title => 'string, required',
+    :review_body => 'text, optional',
+    :author => 'string, required',
+  }.freeze
+
   def index
+    return render :json => { :status => 404, :message => PRODUCT_DOES_NOT_EXIST_ERROR_MESSAGE, :id => params[:id] }, :status => 404 unless Product.exists?(params[:id])
     sort_by = index_params[:sort_by] || SortBy::CREATED_AT
     sort_order = index_params[:sort_order] || SortOrder::DESC
+
+    return render :json => { :status => 400, :message => PRODUCT_RATING_SORT_ERROR_MESSAGE }, :status => 400 if !SortBy::ALL.include?(sort_by) || !SortOrder::ALL.include?(sort_order)
 
     @product_ratings = Product.find(index_params[:id]).product_ratings.order(sort_by + ' ' + sort_order)
 
@@ -24,6 +38,8 @@ class RatingController < ApplicationController
   end
 
   def create
+    return render :json => { :status => 404, :message => PRODUCT_DOES_NOT_EXIST_ERROR_MESSAGE, :id => params[:id] }, :status => 404 unless Product.exists?(params[:id])
+
     @new_product_rating = ProductRating.new(
       :author => create_params[:author],
       :rating => create_params[:rating],
@@ -35,6 +51,8 @@ class RatingController < ApplicationController
       render :json => {
         :id => @new_product_rating.id
       }
+    else
+      render :json => { :status => 400, :message => PRODUCT_RATING_SAVE_ERROR_MESSAGE, :valid_params => VALID_CREATE_PARAMS }, :status => 400
     end
   end
 

--- a/app/controllers/rating_controller.rb
+++ b/app/controllers/rating_controller.rb
@@ -6,9 +6,28 @@ class RatingController < ApplicationController
     render json: @product_ratings, status: :ok
   end
 
+  def create
+    @new_product_rating = ProductRating.new(
+      :author => create_params[:author],
+      :rating => create_params[:rating],
+      :review_title => create_params[:review_title],
+      :review_body => create_params[:review_body],
+      :product_id => create_params[:id]
+    )
+    if @new_product_rating.save
+      render :json => {
+        :id => @new_product_rating.id
+      }
+    end
+  end
+
   private
 
   def show_params
     params.permit(:id)
+  end
+
+  def create_params
+    params.permit(:author, :rating, :review_title, :review_body, :id)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -16,4 +16,5 @@
 #
 
 class Product < ApplicationRecord
+  has_many :product_ratings
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -17,4 +17,15 @@
 
 class Product < ApplicationRecord
   has_many :product_ratings
+
+  def average_rating
+    ratings = []
+    product_ratings.each do |product_rating|
+      ratings.append(product_rating.rating)
+    end
+
+    return 0 unless ratings.present?
+
+    ratings.sum(0.0) / ratings.size
+  end
 end

--- a/app/models/product_rating.rb
+++ b/app/models/product_rating.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: product_ratings
+#
+#  id           :uuid             not null, primary key
+#  author       :string           not null
+#  rating       :integer          not null
+#  review_body  :string
+#  review_title :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  product_id   :uuid
+#
+class ProductRating < ApplicationRecord
+  belongs_to :product
+
+  validates :rating, :presence => true, :inclusion => { :in => 1..5 }
+  validates :author, :presence => true
+  validates :review_title, :presence => true
+end

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -1,0 +1,9 @@
+require 'date'
+
+class ProductSerializer < ActiveModel::Serializer
+  attributes :id, :name, :description, :created_at, :updated_at, :average_rating
+
+  def average_rating
+    object.average_rating.round(2)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@
 Rails.application.routes.draw do
   resources :product, only: [:show, :index]
   get "product/:id/product_ratings" => "rating#index"
+  post "product/:id/product_rating" => "rating#create"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 
 Rails.application.routes.draw do
   resources :product, only: [:show, :index]
+  get "product/:id/product_ratings" => "rating#index"
 end

--- a/db/migrate/20220205202429_create_product_ratings.rb
+++ b/db/migrate/20220205202429_create_product_ratings.rb
@@ -1,0 +1,13 @@
+class CreateProductRatings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :product_ratings, id: :uuid do |t|
+      t.string :author, null: false
+      t.integer :rating, null: false, inclusion: [1, 2, 3, 4, 5]
+      t.string :review_title, null: false
+      t.string :review_body
+      t.uuid :product_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_28_233503) do
+ActiveRecord::Schema.define(version: 2022_02_05_202429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "product_ratings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "author", null: false
+    t.integer "rating", null: false
+    t.string "review_title", null: false
+    t.string "review_body"
+    t.uuid "product_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "products", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,5 +8,8 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 5.times do |i|
-  Product.create(name: "product-#{i}", description: "Product #{i}")
+  product = FactoryBot.create(:product, name: "product-#{i}", description: "Product #{i}")
+  3.times do |_j|
+    FactoryBot.create(:product_rating, :product_id => product.id)
+  end
 end

--- a/spec/controllers/product_controller_spec.rb
+++ b/spec/controllers/product_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe RatingController, type: :request do
+  describe "GET /index" do
+    context "returns the products by average rating descending" do
+      let!(:product1) { create(:product) }
+      let!(:product2) { create(:product) }
+
+      let!(:product_rating1) { create(:product_rating, :product_id => product1.id, :rating => 1) }
+      let!(:product_rating2) { create(:product_rating, :product_id => product2.id, :rating => 5) }
+      it "renders json with the products and a 200 " do
+        get "/product"
+
+        expect(JSON.parse(response.body).first["id"]).to eq(product2.id)
+        expect(JSON.parse(response.body).last["id"]).to eq(product1.id)
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+end

--- a/spec/controllers/rating_controller_spec.rb
+++ b/spec/controllers/rating_controller_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe RatingController, type: :request do
+  describe "GET /index" do
+    context "when the product exists" do
+      context "when there are ratings" do
+        let!(:product_rating) { create(:product_rating) }
+
+        it "renders json with the product ratings" do
+          get "/product/#{product_rating.product_id}/product_ratings", :params => { :id => product_rating.product_id }
+
+          expect(JSON.parse(response.body).length).to eq(1)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when there are no ratings" do
+        let!(:product) { create(:product) }
+
+        it "renders json with the product ratings" do
+          get "/product/#{product.id}/product_ratings", :params => { :id => product.id }
+
+          expect(JSON.parse(response.body).length).to eq(0)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when provided proper sorting variables" do
+        let!(:product_rating1) { create(:product_rating, :created_at => Time.new(2022, 2, 2, 10, 0)) }
+        let!(:product_rating2) { create(:product_rating, :created_at => Time.new(2022, 2, 2, 10, 1), :product_id => product_rating1.product_id) }
+
+        it "renders json with the product ratings" do
+          get "/product/#{product_rating1.product_id}/product_ratings", :params => { :id => product_rating1.product_id, :sort_by => "created_at", :sort_order => "desc" }
+
+          expect(JSON.parse(response.body).length).to eq(2)
+          expect(JSON.parse(response.body).first["author"]).to eq(product_rating2.author)
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context "when provided improper sorting variables" do
+        let!(:product_rating1) { create(:product_rating, :created_at => Time.new(2022, 2, 2, 10, 0)) }
+        let!(:product_rating2) { create(:product_rating, :created_at => Time.new(2022, 2, 2, 10, 1), :product_id => product_rating1.product_id) }
+
+        it "renders json with the product ratings" do
+          get "/product/#{product_rating1.product_id}/product_ratings", :params => { :id => product_rating1.product_id, :sort_by => "created_attt", :sort_order => "descccc" }
+
+          expect(JSON.parse(response.body)["message"]).to eq(described_class::PRODUCT_RATING_SORT_ERROR_MESSAGE)
+          expect(response.status).to eq(400)
+        end
+      end
+    end
+
+    context "when the product does not exist" do
+      it "renders json with an error message and 400 " do
+        get "/product/asdf12344321/product_ratings", :params => { :id => "asdf12344321" }
+
+        expect(JSON.parse(response.body)["message"]).to eq(described_class::PRODUCT_DOES_NOT_EXIST_ERROR_MESSAGE)
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "POST /create" do
+    context "when provided correct paramters" do
+      let!(:product) { create(:product) }
+
+      it "saves a new rating" do
+        expect(product.product_ratings.length).to eq(0)
+        post "/product/#{product.id}/product_rating", :params => { :id => product.id, :author => "Baker", :rating => 3, :review_title => "Title" }
+
+        expect(JSON.parse(response.body)["id"]).not_to be(nil)
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when provided incorrect paramters" do
+      let!(:product) { create(:product) }
+
+      it "saves a new rating" do
+        expect(product.product_ratings.length).to eq(0)
+        post "/product/#{product.id}/product_rating", :params => { :id => product.id, :author => "Baker" }
+
+        expect(JSON.parse(response.body)["message"]).not_to be(described_class::PRODUCT_RATING_SAVE_ERROR_MESSAGE)
+        expect(response.status).to eq(400)
+      end
+    end
+  end
+end

--- a/spec/factories/product_ratings.rb
+++ b/spec/factories/product_ratings.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: product_ratings
+#
+#  id           :uuid             not null, primary key
+#  author       :string           not null
+#  rating       :integer          not null
+#  review_body  :string
+#  review_title :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  product_id   :uuid
+#
+FactoryBot.define do
+  factory :product_rating do
+    author { Faker::Name.unique.name }
+    rating { rand(1..5) }
+    review_title { 'This product is great' }
+    review_body { Faker::Quote.yoda }
+    product_id { FactoryBot.create(:product).id }
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: products
+#
+#  id          :uuid             not null, primary key
+#  description :string
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_products_on_name  (name) UNIQUE
+#
+
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+  describe "#average_rating" do
+    subject { product.average_rating }
+
+    context "when there are no ratings" do
+      let(:product) { build(:product) }
+
+      it "returns 0" do
+        expect(subject).to eq(0)
+      end
+    end
+
+    context "when there are ratings" do
+      let(:product) { create(:product) }
+      let!(:product_rating1) { create(:product_rating, :product_id => product.id, :rating => 5) }
+      let!(:product_rating2) { create(:product_rating, :product_id => product.id, :rating => 1) }
+
+      it "corretly calculates the average" do
+        expect(subject).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/workers/base_worker_spec.rb
+++ b/spec/workers/base_worker_spec.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe BaseWorker, type: :worker do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
## Background
During the interview process for oliver.space, I have been tasked with adding two new enpoints to this API. The existing endpoints are:
* `GET /product`: returns all products as a JSON array.
* `GET /product/:id`: returns a single product.

## Solution
These endpoints allow you to view the product ratings for a particular product, and upload a new one. Here I am adding:
* `GET /product/:id/product_ratings`
  * params:
    * `sort_by` sort type for reviews, optional, valid: `created_at`, `rating`
    * `sort_order` sort order for reviews, optional, valid: `asc`, `desc`
* `POST /product/:id/product_rating`
  * params:
    * `author` of the review, required, string
    * `rating` between 1 and 5 (inclusive), required, integer
    * `review_title` required, string
    * `review_body` optional, text
    * `id` id of the product to review, required, uuid

Other Changes:
* `GET /product`: returns all products as a JSON array.
  * This now returns all products, sorted in descending order by average rating (average rating is 0 if there are no ratings)
* a product serializer is added to include the average rating when returning a product object. Affected endpoints:
  * `GET /product`: returns all products as a JSON array.
  * `GET /product/:id`: returns a single product.